### PR TITLE
Module names can't start with a number.

### DIFF
--- a/25519.podspec
+++ b/25519.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |spec|
   spec.source_files = 'Classes/*.{h,m}', 'Sources/Curve25519/curve25519-donna.c', 'Sources/ed25519/*.{c,h}', 'Sources/ed25519/additions/*.{c,h}', 'Sources/ed25519/nacl_sha512/*.{c,h}', 'Sources/ed25519/nacl_includes/*.{c,h}'
   #spec.private_header_files = 'Sources/ed25519/nacl_includes/*.h','Sources/ed25519/additions/*.h', 'Sources/ed25519/nacl_sha512/*.h'
   spec.framework    = 'Security'
+  spec.module_name = 'Curve25519Kit'
   spec.public_header_files = "Classes/*.h"
   spec.requires_arc = true
 end


### PR DESCRIPTION
Else Cocoapods chooses the module name _25519 when `use_frameworks!` is
enabled.

As in `#import <_25519/Curve25519.h>`

If you're not worried about a bigger breaking change, it probably makes sense to be consistent and rename the pod all together.

**edit:** More specifically, since this affects how downstream libraries will include the pod, if you want to support downstream dependencies that work as both frameworks and static libs, and not just one or the other, we should change this throughout.
