### PR TITLE
Fix Xcode warnings

### DIFF
--- a/Sources/Curve25519/curve25519-donna.c
+++ b/Sources/Curve25519/curve25519-donna.c
@@ -477,7 +477,7 @@ fcontract(u8 *output, limb *input_limbs) {
 
   /* |input_limbs[i]| < 2^26, so it's valid to convert to an s32. */
   for (i = 0; i < 10; i++) {
-    input[i] = input_limbs[i];
+    input[i] = (s32) input_limbs[i];
   }
 
   for (j = 0; j < 2; ++j) {

--- a/Sources/ed25519/additions/curve_sigs.c
+++ b/Sources/ed25519/additions/curve_sigs.c
@@ -8,7 +8,7 @@ void curve25519_keygen(unsigned char* curve25519_pubkey_out,
                        const unsigned char* curve25519_privkey_in)
 {
   ge_p3 ed; /* Ed25519 pubkey point */
-  fe ed_y, ed_y_plus_one, one_minus_ed_y, inv_one_minus_ed_y;
+  fe ed_y_plus_one, one_minus_ed_y, inv_one_minus_ed_y;
   fe mont_x;
 
   /* Perform a fixed-base multiplication of the Edwards base point,

--- a/Sources/ed25519/additions/zeroize.c
+++ b/Sources/ed25519/additions/zeroize.c
@@ -3,7 +3,6 @@
 void zeroize(unsigned char* b, size_t len)
 {
   size_t count = 0;
-  unsigned long retval = 0;
   volatile unsigned char *p = b;
 
   for (count = 0; count < len; count++)

--- a/Sources/ed25519/fe_frombytes.c
+++ b/Sources/ed25519/fe_frombytes.c
@@ -60,14 +60,14 @@ void fe_frombytes(fe h,const unsigned char *s)
   carry6 = (h6 + (crypto_int64) (1<<25)) >> 26; h7 += carry6; h6 -= carry6 << 26;
   carry8 = (h8 + (crypto_int64) (1<<25)) >> 26; h9 += carry8; h8 -= carry8 << 26;
 
-  h[0] = h0;
-  h[1] = h1;
-  h[2] = h2;
-  h[3] = h3;
-  h[4] = h4;
-  h[5] = h5;
-  h[6] = h6;
-  h[7] = h7;
-  h[8] = h8;
-  h[9] = h9;
+  h[0] = (crypto_int32) h0;
+  h[1] = (crypto_int32) h1;
+  h[2] = (crypto_int32) h2;
+  h[3] = (crypto_int32) h3;
+  h[4] = (crypto_int32) h4;
+  h[5] = (crypto_int32) h5;
+  h[6] = (crypto_int32) h6;
+  h[7] = (crypto_int32) h7;
+  h[8] = (crypto_int32) h8;
+  h[9] = (crypto_int32) h9;
 }

--- a/Sources/ed25519/fe_mul.c
+++ b/Sources/ed25519/fe_mul.c
@@ -240,14 +240,14 @@ void fe_mul(fe h,const fe f,const fe g)
   /* |h0| <= 2^25; from now on fits into int32 unchanged */
   /* |h1| <= 1.01*2^24 */
 
-  h[0] = h0;
-  h[1] = h1;
-  h[2] = h2;
-  h[3] = h3;
-  h[4] = h4;
-  h[5] = h5;
-  h[6] = h6;
-  h[7] = h7;
-  h[8] = h8;
-  h[9] = h9;
+  h[0] = (crypto_int32) h0;
+  h[1] = (crypto_int32) h1;
+  h[2] = (crypto_int32) h2;
+  h[3] = (crypto_int32) h3;
+  h[4] = (crypto_int32) h4;
+  h[5] = (crypto_int32) h5;
+  h[6] = (crypto_int32) h6;
+  h[7] = (crypto_int32) h7;
+  h[8] = (crypto_int32) h8;
+  h[9] = (crypto_int32) h9;
 }

--- a/Sources/ed25519/fe_sq.c
+++ b/Sources/ed25519/fe_sq.c
@@ -136,14 +136,14 @@ void fe_sq(fe h,const fe f)
 
   carry0 = (h0 + (crypto_int64) (1<<25)) >> 26; h1 += carry0; h0 -= carry0 << 26;
 
-  h[0] = h0;
-  h[1] = h1;
-  h[2] = h2;
-  h[3] = h3;
-  h[4] = h4;
-  h[5] = h5;
-  h[6] = h6;
-  h[7] = h7;
-  h[8] = h8;
-  h[9] = h9;
+  h[0] = (crypto_int32) h0;
+  h[1] = (crypto_int32) h1;
+  h[2] = (crypto_int32) h2;
+  h[3] = (crypto_int32) h3;
+  h[4] = (crypto_int32) h4;
+  h[5] = (crypto_int32) h5;
+  h[6] = (crypto_int32) h6;
+  h[7] = (crypto_int32) h7;
+  h[8] = (crypto_int32) h8;
+  h[9] = (crypto_int32) h9;
 }

--- a/Sources/ed25519/fe_sq2.c
+++ b/Sources/ed25519/fe_sq2.c
@@ -147,14 +147,14 @@ void fe_sq2(fe h,const fe f)
 
   carry0 = (h0 + (crypto_int64) (1<<25)) >> 26; h1 += carry0; h0 -= carry0 << 26;
 
-  h[0] = h0;
-  h[1] = h1;
-  h[2] = h2;
-  h[3] = h3;
-  h[4] = h4;
-  h[5] = h5;
-  h[6] = h6;
-  h[7] = h7;
-  h[8] = h8;
-  h[9] = h9;
+  h[0] = (crypto_int32) h0;
+  h[1] = (crypto_int32) h1;
+  h[2] = (crypto_int32) h2;
+  h[3] = (crypto_int32) h3;
+  h[4] = (crypto_int32) h4;
+  h[5] = (crypto_int32) h5;
+  h[6] = (crypto_int32) h6;
+  h[7] = (crypto_int32) h7;
+  h[8] = (crypto_int32) h8;
+  h[9] = (crypto_int32) h9;
 }

--- a/Sources/ed25519/nacl_sha512/hash.c
+++ b/Sources/ed25519/nacl_sha512/hash.c
@@ -40,7 +40,7 @@ int crypto_hash_sha512(unsigned char *out,const unsigned char *in,unsigned long 
   padded[inlen] = 0x80;
 
   if (inlen < 112) {
-    for (i = inlen + 1;i < 119;++i) padded[i] = 0;
+    for (i = (int) inlen + 1;i < 119;++i) padded[i] = 0;
     padded[119] = bytes >> 61;
     padded[120] = bytes >> 53;
     padded[121] = bytes >> 45;
@@ -52,7 +52,7 @@ int crypto_hash_sha512(unsigned char *out,const unsigned char *in,unsigned long 
     padded[127] = bytes << 3;
     blocks(h,padded,128);
   } else {
-    for (i = inlen + 1;i < 247;++i) padded[i] = 0;
+    for (i = (int) inlen + 1;i < 247;++i) padded[i] = 0;
     padded[247] = bytes >> 61;
     padded[248] = bytes >> 53;
     padded[249] = bytes >> 45;


### PR DESCRIPTION
Fixes the 'implicit conversion' and 'unused variable' warnings when using this project in Xcode, by adding the explicit type conversions and removing the two unused variables.